### PR TITLE
Add more intelligent root handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ kind-load-deps:
 	docker pull quay.io/jetstack/cert-manager-cainjector:$(CERT_MANAGER_VERSION)
 	docker pull quay.io/jetstack/cert-manager-startupapicheck:$(CERT_MANAGER_VERSION)
 	docker pull quay.io/jetstack/trust-manager:$(TRUST_MANAGER_VERSION)
+	docker pull quay.io/jetstack/cert-manager-package-debian:20210119.0
 	docker pull quay.io/jetstack/cert-manager-csi-driver-spiffe:$(CSI_DRIVER_SPIFFE_VERSION)
 	docker pull quay.io/jetstack/cert-manager-csi-driver-spiffe-approver:$(CSI_DRIVER_SPIFFE_VERSION)
 	kind load docker-image --name $(kind_cluster) quay.io/jetstack/cert-manager-controller:$(CERT_MANAGER_VERSION)
@@ -71,6 +72,7 @@ kind-load-deps:
 	kind load docker-image --name $(kind_cluster) quay.io/jetstack/cert-manager-cainjector:$(CERT_MANAGER_VERSION)
 	kind load docker-image --name $(kind_cluster) quay.io/jetstack/cert-manager-startupapicheck:$(CERT_MANAGER_VERSION)
 	kind load docker-image --name $(kind_cluster) quay.io/jetstack/trust-manager:$(TRUST_MANAGER_VERSION)
+	docker pull quay.io/jetstack/cert-manager-package-debian:20210119.0
 	kind load docker-image --name $(kind_cluster) quay.io/jetstack/cert-manager-csi-driver-spiffe:$(CSI_DRIVER_SPIFFE_VERSION)
 	kind load docker-image --name $(kind_cluster) quay.io/jetstack/cert-manager-csi-driver-spiffe-approver:$(CSI_DRIVER_SPIFFE_VERSION)
 
@@ -84,6 +86,7 @@ kind-setup:
 	helm install trust-manager jetstack/trust-manager \
 		--version $(TRUST_MANAGER_VERSION) \
 		--namespace cert-manager \
+		--set "defaultPackageImage.tag=20210119.0" \
 		--wait
 	helm install cert-manager-csi-driver-spiffe jetstack/cert-manager-csi-driver-spiffe --wait \
 		--namespace cert-manager \

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,10 @@ CERT_MANAGER_VERSION=v1.16.1
 TRUST_MANAGER_VERSION=v0.12.0
 CSI_DRIVER_SPIFFE_VERSION=v0.8.1
 
+.PHONY: cluster
+cluster:
+	./cluster.sh
+
 .PHONY: kind-load-deps
 kind-load-deps:
 	docker pull quay.io/jetstack/cert-manager-controller:$(CERT_MANAGER_VERSION)
@@ -103,7 +107,7 @@ curl_flags=-sS --cacert infrastructure/root.pem
 
 .PHONY: get-token
 get-token:
-	curl $(curl_flags) --cert infrastructure/client.crt --key infrastructure/client.key \
+	curl $(curl_flags) --cert _bin/client.crt --key _bin/client.key \
 		-XPOST \
 		-d "grant_type=urn:ietf:params:oauth:grant-type:token-exchange&subject_token_type=urn:ietf:params:oauth:token-type:tls-client-auth&&aud=abc123" \
 		https://localhost:9966/token \

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# token-exchange
+
+This is the sister repo with demo code from our KubeCon NA 2024 talk in Salt Lake City, UT: [SPIFFE the Easy Way: Universal X509 and JWT Identities Using cert-manager](https://kccncna2024.sched.com/event/1i7rz).
+
+## Running Locally
+
+You'll need a root certificate to be configured; you can create this in any Kubernetes cluster running cert-manager by applying `infrastructure/spiffe_roots.yaml`.
+
+Once created, you can extract the root using kubectl.
+
+For example:
+
+```text
+kubectl apply -f infrastructure/spiffe_roots.yaml
+mkdir _bin
+kubectl get -n spiffe-roots-gen secrets root-secret-1 -oyaml > _bin/root.yaml
+# Manually edit the file to remove:
+# - metadata.annotations
+# - metadata.labels
+# - metadata.resourceVersion
+# - metadata.uid
+# - metadata.creationTimestamp
+# Also change:
+# - metadata.name to "root-secret"
+# - metadata.namespace to "cert-manager"
+```
+
+Once completed, you can run `make cluster` to create a kind cluster running the example.

--- a/cluster.sh
+++ b/cluster.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+cert_yaml=_bin/root.yaml
+
+if [[ ! -f $cert_yaml ]]; then
+	echo "Expected $cert_yaml to exist; exiting"
+	exit 1
+fi
+
+kind delete clusters token-exchange || :
+kind create cluster --name token-exchange
+
+make kind-load
+make kind-load-deps
+make kind-setup
+
+kubectl apply -f $cert_yaml
+
+kubectl apply -f infrastructure/deployment.yaml
+
+kubectl apply -f infrastructure/clientcert.yaml
+
+kubectl wait --for=condition=Ready certificates/client-cert
+
+kubectl get -n default secrets client-cert -ojson | jq -r '.data."tls.crt"' | base64 -d > _bin/client.crt
+kubectl get -n default secrets client-cert -ojson | jq -r '.data."tls.key"' | base64 -d > _bin/client.key

--- a/infrastructure/clientcert.yaml
+++ b/infrastructure/clientcert.yaml
@@ -12,8 +12,8 @@ spec:
     organizations:
     - cert-manager
   uris:
-  - spiffe://example.com/client-cert
-  duration: 43800h  # 5 years
+  - spiffe://tim-ramlot-gcp.jetstacker.net/client-cert
+  duration: 8760h  # 1 year
   privateKey:
     algorithm: ECDSA
     size: 256

--- a/infrastructure/deployment.yaml
+++ b/infrastructure/deployment.yaml
@@ -6,33 +6,44 @@ metadata:
 ---
 
 apiVersion: v1
-kind: Secret
-metadata:
-  name: root-secret
-  namespace: cert-manager
-type: kubernetes.io/tls
-stringData:
-  tls.crt: |-
-    -----BEGIN CERTIFICATE-----
-    ...
-    -----END CERTIFICATE-----
-  tls.key: |-
-    -----BEGIN EC PRIVATE KEY-----
-    ...
-    -----END EC PRIVATE KEY-----
-
----
-
-apiVersion: v1
 kind: ConfigMap
 metadata:
   name: root-cert-trust
   namespace: cert-manager
 data:
   root.pem: |-
-    -----BEGIN CERTIFICATE-----
-    ...
-    -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+      MIIBtDCCAVqgAwIBAgIRAOHjzYfpkQOZ30peD2mEMQkwCgYIKoZIzj0EAwIwIDEe
+      MBwGA1UEAxMVdG9rZW4tZXhjaGFuZ2Utcm9vdC0xMB4XDTI0MTAyNDA5MjMyMVoX
+      DTI5MTAyMzA5MjMyMVowIDEeMBwGA1UEAxMVdG9rZW4tZXhjaGFuZ2Utcm9vdC0x
+      MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1TqqCSrML6ugr2YPai6+Y1PvxYAb
+      GY0RMKeqxyYwMD7giVCYRdDEl2eQDXadC/4bspVdNo7BRxDkwozCEJYeoqN1MHMw
+      DgYDVR0PAQH/BAQDAgKkMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFL+9iqCe
+      hIEhhnh+UmAjiz6UWV8OMDEGA1UdEQQqMCiGJnNwaWZmZTovL3RpbS1yYW1sb3Qt
+      Z2NwLmpldHN0YWNrZXIubmV0MAoGCCqGSM49BAMCA0gAMEUCIEKsIPnzZ8xSSdT6
+      w8u5uuHbQqKpO/tXNSTI0WF+HXkOAiEAkNsmtHx7rWVnz1i/xMQiQXNWsU45heDc
+      Ow0HyT1Fik8=
+      -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+      MIIDPzCCAiegAwIBAgIQSpx3RiyMAYcsW5ZifZMC+DANBgkqhkiG9w0BAQsFADAg
+      MR4wHAYDVQQDExV0b2tlbi1leGNoYW5nZS1yb290LTIwHhcNMjQxMDI0MDkyMzIx
+      WhcNMjkxMDIzMDkyMzIxWjAgMR4wHAYDVQQDExV0b2tlbi1leGNoYW5nZS1yb290
+      LTIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCc7YoxMSw2nQqTxKq6
+      xUTBYbUonQXiB0oFGTeqbbsZ8nQaH1F9L9IWr/J3dg1UJEoJXZuxhnecn1MTxw7z
+      SF10YC5fbUTaa32nwLD2Q+00t3cfAeP/aWWn3sFWg9/0LSrwN/ImmHRwgQB6IO9+
+      TRGb5XyXTcdUW6GuZlHgmI6E8oQC35MzoJAtHAZSyMXEgk958PtK6RM2ZdlKUkLA
+      UIYz7h9CNnfO6kAYlK4OTA3sIGetm2nNHjt1dj+bJ1hzjfKGzbam2wZ+T0f5nqmy
+      rplv4DXdp/jjwvF1h7eCm4iu59Ancg2MHuqj+DR4Cu6B6LF8OyVQvTEQ6YPXOV9k
+      jRwxAgMBAAGjdTBzMA4GA1UdDwEB/wQEAwICpDAPBgNVHRMBAf8EBTADAQH/MB0G
+      A1UdDgQWBBQs78nNzwnJxUhsXRDimZiiWxkXQzAxBgNVHREEKjAohiZzcGlmZmU6
+      Ly90aW0tcmFtbG90LWdjcC5qZXRzdGFja2VyLm5ldDANBgkqhkiG9w0BAQsFAAOC
+      AQEAY2kvo4Veg+WtC+QnhFto7SHqNXq6vcMRA0YvkPz4EJ4bk+1lypYjMhgkH73p
+      lmYzIwhVgOL2r3qnWIQVtjswR/v5XlaoUjz/iWW8AOjWxpuEKaHli0ywcV296KD+
+      ylzpPE1+E0KAu4QGUfJ9RRKzcdgzMFJxO0Pi1AWdigW4F/RS7kDqDfLU75fxDZM1
+      7/IEOju4IxiNkVdPrDTriqpYDzuLSvUZo26Cyt8DTsfH4uqY4IXzI+AX5vU8B6Wf
+      HPPeb4FjAwdm4zsppvChhlFOsDvN2GxM53yqVx2RqTtxB4yyfVsSWnXtxlun9LpD
+      5fIaTLWU/1NOkgpmDZGbncupFw==
+      -----END CERTIFICATE-----
 
 ---
 

--- a/infrastructure/spiffe_roots.yaml
+++ b/infrastructure/spiffe_roots.yaml
@@ -1,7 +1,15 @@
-apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
+apiVersion: v1
+kind: Namespace
 metadata:
-  name: selfsigned-issuer
+  name: spiffe-roots-gen
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: rootsgen-selfsigned-issuer
+  namespace: spiffe-roots-gen
 spec:
   selfSigned: {}
 
@@ -11,6 +19,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: token-exchange-root-1
+  namespace: spiffe-roots-gen
 spec:
   isCA: true
   commonName: token-exchange-root-1
@@ -21,8 +30,8 @@ spec:
     algorithm: ECDSA
     size: 256
   issuerRef:
-    name: selfsigned-issuer
-    kind: ClusterIssuer
+    name: rootsgen-selfsigned-issuer
+    kind: Issuer
     group: cert-manager.io
 
 ---
@@ -32,6 +41,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: token-exchange-root-2
+  namespace: spiffe-roots-gen
 spec:
   isCA: true
   commonName: token-exchange-root-2
@@ -42,6 +52,6 @@ spec:
     algorithm: RSA
     size: 2048
   issuerRef:
-    name: selfsigned-issuer
-    kind: ClusterIssuer
+    name: rootsgen-selfsigned-issuer
+    kind: Issuer
     group: cert-manager.io

--- a/infrastructure/spiffe_roots.yaml
+++ b/infrastructure/spiffe_roots.yaml
@@ -1,0 +1,47 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-issuer
+spec:
+  selfSigned: {}
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: token-exchange-root-1
+spec:
+  isCA: true
+  commonName: token-exchange-root-1
+  secretName: root-secret-1
+  duration: 43800h # 365 days * 5
+  uris: ["spiffe://tim-ramlot-gcp.jetstacker.net"]
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+
+---
+
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: token-exchange-root-2
+spec:
+  isCA: true
+  commonName: token-exchange-root-2
+  secretName: root-secret-2
+  duration: 43800h # 365 days * 5
+  uris: ["spiffe://tim-ramlot-gcp.jetstacker.net"]
+  privateKey:
+    algorithm: RSA
+    size: 2048
+  issuerRef:
+    name: selfsigned-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io


### PR DESCRIPTION
The `_bin/root.yaml` that's required is shared out side of github and must be manually created.