### PR TITLE
Use RSA key since Azure and AWS only seem to support RS256

### DIFF
--- a/cmd/token-exchange/main.go
+++ b/cmd/token-exchange/main.go
@@ -97,7 +97,7 @@ func run(ctx context.Context, logger *slog.Logger) error {
 
 		logger.Info("loaded new root fingerprint", "hex", fprint.Hex())
 
-		sk, err := fprint.DeriveECDSASigningKey(secretKey)
+		sk, err := fprint.DeriveRSASigningKey(secretKey)
 		if err != nil {
 			return err
 		}

--- a/fingerprint/rsa_keygen.go
+++ b/fingerprint/rsa_keygen.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2024 Venafi
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fingerprint
+
+import (
+	"crypto/rsa"
+	"errors"
+	"io"
+	"math"
+	"math/big"
+)
+
+// Code in this file is based on the Go standard library crypto/rsa package.
+// See https://cs.opensource.google/go/go/+/refs/tags/go1.23.2:src/crypto/rsa/rsa.go
+// The LICENSE that applies here is https://cs.opensource.google/go/go/+/refs/tags/go1.23.2:LICENSE
+
+// based on crypto/rsa.GenerateKey, but without the randutil.MaybeReadByte invocation
+// so it can be used to deterministically generate keys.
+func GenerateKey(random io.Reader, bits int) (*rsa.PrivateKey, error) {
+	return GenerateMultiPrimeKey(random, 2, bits)
+}
+
+var bigOne = big.NewInt(1)
+
+// based on crypto/rsa.GenerateMultiPrimeKey, but without the randutil.MaybeReadByte invocation
+// so it can be used to deterministically generate keys.
+func GenerateMultiPrimeKey(random io.Reader, nprimes int, bits int) (*rsa.PrivateKey, error) {
+	priv := new(rsa.PrivateKey)
+	priv.E = 65537
+
+	if nprimes < 2 {
+		return nil, errors.New("crypto/rsa: GenerateMultiPrimeKey: nprimes must be >= 2")
+	}
+
+	if bits < 64 {
+		primeLimit := float64(uint64(1) << uint(bits/nprimes))
+		// pi approximates the number of primes less than primeLimit
+		pi := primeLimit / (math.Log(primeLimit) - 1)
+		// Generated primes start with 11 (in binary) so we can only
+		// use a quarter of them.
+		pi /= 4
+		// Use a factor of two to ensure that key generation terminates
+		// in a reasonable amount of time.
+		pi /= 2
+		if pi <= float64(nprimes) {
+			return nil, errors.New("crypto/rsa: too few primes of given length to generate an RSA key")
+		}
+	}
+
+	primes := make([]*big.Int, nprimes)
+
+NextSetOfPrimes:
+	for {
+		todo := bits
+		// crypto/rand should set the top two bits in each prime.
+		// Thus each prime has the form
+		//   p_i = 2^bitlen(p_i) × 0.11... (in base 2).
+		// And the product is:
+		//   P = 2^todo × α
+		// where α is the product of nprimes numbers of the form 0.11...
+		//
+		// If α < 1/2 (which can happen for nprimes > 2), we need to
+		// shift todo to compensate for lost bits: the mean value of 0.11...
+		// is 7/8, so todo + shift - nprimes * log2(7/8) ~= bits - 1/2
+		// will give good results.
+		if nprimes >= 7 {
+			todo += (nprimes - 2) / 5
+		}
+		for i := 0; i < nprimes; i++ {
+			var err error
+			primes[i], err = Prime(random, todo/(nprimes-i))
+			if err != nil {
+				return nil, err
+			}
+			todo -= primes[i].BitLen()
+		}
+
+		// Make sure that primes is pairwise unequal.
+		for i, prime := range primes {
+			for j := 0; j < i; j++ {
+				if prime.Cmp(primes[j]) == 0 {
+					continue NextSetOfPrimes
+				}
+			}
+		}
+
+		n := new(big.Int).Set(bigOne)
+		totient := new(big.Int).Set(bigOne)
+		pminus1 := new(big.Int)
+		for _, prime := range primes {
+			n.Mul(n, prime)
+			pminus1.Sub(prime, bigOne)
+			totient.Mul(totient, pminus1)
+		}
+		if n.BitLen() != bits {
+			// This should never happen for nprimes == 2 because
+			// crypto/rand should set the top two bits in each prime.
+			// For nprimes > 2 we hope it does not happen often.
+			continue NextSetOfPrimes
+		}
+
+		priv.D = new(big.Int)
+		e := big.NewInt(int64(priv.E))
+		ok := priv.D.ModInverse(e, totient)
+
+		if ok != nil {
+			priv.Primes = primes
+			priv.N = n
+			break
+		}
+	}
+
+	priv.Precompute()
+	return priv, nil
+}
+
+// based on crypto/rsa.Prime, but without the randutil.MaybeReadByte invocation
+// so it can be used to deterministically generate keys.
+func Prime(rand io.Reader, bits int) (*big.Int, error) {
+	if bits < 2 {
+		return nil, errors.New("crypto/rand: prime size must be at least 2-bit")
+	}
+
+	b := uint(bits % 8)
+	if b == 0 {
+		b = 8
+	}
+
+	bytes := make([]byte, (bits+7)/8)
+	p := new(big.Int)
+
+	for {
+		if _, err := io.ReadFull(rand, bytes); err != nil {
+			return nil, err
+		}
+
+		// Clear bits in the first byte to make sure the candidate has a size <= bits.
+		bytes[0] &= uint8(int(1<<b) - 1)
+		// Don't let the value be too small, i.e, set the most significant two bits.
+		// Setting the top two bits, rather than just the top bit,
+		// means that when two of these values are multiplied together,
+		// the result isn't ever one bit short.
+		if b >= 2 {
+			bytes[0] |= 3 << (b - 2)
+		} else {
+			// Here b==1, because b cannot be zero.
+			bytes[0] |= 1
+			if len(bytes) > 1 {
+				bytes[1] |= 0x80
+			}
+		}
+		// Make the value odd since an even number this large certainly isn't prime.
+		bytes[len(bytes)-1] |= 1
+
+		p.SetBytes(bytes)
+		if p.ProbablyPrime(20) {
+			return p, nil
+		}
+	}
+}

--- a/tokenserver/tokenserver.go
+++ b/tokenserver/tokenserver.go
@@ -163,7 +163,7 @@ func (ts *tokenServer) handleTokenRequest(r *http.Request) srvtool.Response {
 		ExpiresAt: jwtgen.NewNumericDate(expiresAt),
 	}
 
-	token := jwtgen.NewWithClaims(jwtgen.SigningMethodES256, claims)
+	token := jwtgen.NewWithClaims(jwtgen.SigningMethodRS256, claims)
 	token.Header["kid"] = fprint.Hex()
 
 	jwt, err := token.SignedString(key)

--- a/tokenserver/tokenserver_test.go
+++ b/tokenserver/tokenserver_test.go
@@ -21,6 +21,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -142,8 +143,8 @@ func Test_handleTokenRequest(t *testing.T) {
 			srvtool.JSONHandler(
 				(&tokenServer{
 					roots: fingerprint.RootMap{
-						rootFingerprint: func() *ecdsa.PrivateKey {
-							pk, err := rootFingerprint.DeriveECDSASigningKey([]byte("test"))
+						rootFingerprint: func() *rsa.PrivateKey {
+							pk, err := rootFingerprint.DeriveRSASigningKey([]byte("test"))
 							require.NoError(t, err)
 							return pk
 						}(),

--- a/wellknownserver/wellknownserver.go
+++ b/wellknownserver/wellknownserver.go
@@ -159,7 +159,7 @@ func (wks *wellKnownServer) handleJWKs(r *http.Request) srvtool.Response {
 	response := jose.JSONWebKeySet{
 		Keys: []jose.JSONWebKey{
 			{
-				Algorithm: string(jose.ES256), // TODO: should vary on key type?
+				Algorithm: string(jose.RS256), // TODO: should vary on key type?
 				Key:       publicKey,
 				KeyID:     fprint.Hex(),
 				Use:       "sig",


### PR DESCRIPTION
Both Azure and AWS do not seem to support ES256, meaning we have to deterministically generate RSA keys instead.
This ofc. is not easy:
1. RSA key generation can be quite compute intensive
2. The Go RSA key generation logic does not want us to use it as a deterministic method, since they want to be able to change their algorithm in the future. We thus have to make a copy of their key generation logic.